### PR TITLE
Use locally installed PhantomJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ sudo npm install -g ddg-screen-diff
 
 With a Debian-based Linux distro you may get an error like `node: not found`. The fix for that is to install the `nodejs-legacy` package (`sudo apt-get install nodejs-legacy`).
 
-Also, make sure that you've got PhantomJS and ImageMagick (or GraphicsMagick) in your $PATH.
+Also, make sure that you've got ImageMagick (or GraphicsMagick) in your $PATH.
 
 Usage
 ---

--- a/lib/selenium/screenshot.js
+++ b/lib/selenium/screenshot.js
@@ -2,7 +2,9 @@ var webdriver = require("selenium-webdriver"),
     browserData = require("../data/browsers"),
     actions = require("./actions"),
     BBPromise = require("bluebird"),
-    until = webdriver.until;
+    until = webdriver.until,
+
+    PHANTOM_PATH = __dirname + "/../../node_modules/.bin/phantomjs";
 
 /**
  * Helper method, waits until everything on the page has loaded
@@ -128,7 +130,8 @@ function getDriver(task, cachedDrivers) {
     } else {
         builder
             .withCapabilities({
-                "phantomjs.cli.args": "--ssl-protocol=any"
+                "phantomjs.cli.args": "--ssl-protocol=any",
+                "phantomjs.binary.path": PHANTOM_PATH
             })
             .forBrowser("phantomjs");
     }

--- a/package.json
+++ b/package.json
@@ -3,16 +3,17 @@
   "version": "0.1.4",
   "description": "Visual regression tool for DuckDuckGo",
   "bin": {
-      "ddg-screen-diff": "./lib/run.js"
+    "ddg-screen-diff": "./lib/run.js"
   },
   "main": "./lib/run.js",
   "repository": {
-      "type": "git",
-      "url": "https://github.com/duckduckgo/ddg-screen-diff"
+    "type": "git",
+    "url": "https://github.com/duckduckgo/ddg-screen-diff"
   },
   "dependencies": {
     "bluebird": "2.9.33",
     "gm": "1.18.1",
+    "phantomjs-prebuilt": "2.1.4",
     "selenium-webdriver": "2.46.1",
     "yargs": "3.15.0"
   }


### PR DESCRIPTION
This allows us to ignore whatever PhantomJS is installed globally and just use a local one.

In this case, we're using PhantomJS 2.1. :ghost:

To verify, pull the latest, do `npm install && ./lib/run.js search "test"` and bask in how amazingly well the fonts are now rendering.

@jagtalon 
cc @bsstoner 
