### PR TITLE
Removed jQuery dependency for PhantomJS no-touch

### DIFF
--- a/lib/selenium/screenshot.js
+++ b/lib/selenium/screenshot.js
@@ -66,7 +66,7 @@ function tryAndLoadUrl(url, driver, deferred) {
     // so I added .no-touch class manually.
     driver.executeScript(function() {
         if (window.callPhantom) {
-            $('html').addClass("no-touch");
+            document.querySelector("html").className += " no-touch";
         }
     });
 


### PR DESCRIPTION
Hey @jagtalon, I missed this when reviewing the other day. If you try to take a screenshot when the page is in a broken state, jQuery will not have loaded so things explode.

I've recreated your fix with vanilla JS - so if the page is broken, we can hit the retry logic a bit further on.

Sorry, I really should've caught that!
