### PR TITLE
Downgrade to an earlier version of phantomjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "compressjs": "1.0.3",
     "gm": "1.23.0",
     "request": "2.74.0",
-    "phantomjs-prebuilt": "2.1.11",
+    "phantomjs": "1.9.8",
     "selenium-webdriver": "2.53.2",
     "yargs": "3.32.0"
   }


### PR DESCRIPTION
Because Phantom 2+ errors out when it comes to CSP headers. Stopgap before switching to headless Chrome.