### PR TITLE
Include Mobile User Agent for small sizes

### DIFF
--- a/lib/selenium/screenshot.js
+++ b/lib/selenium/screenshot.js
@@ -137,14 +137,19 @@ function getDriver(task, cachedDrivers) {
             .withCapabilities(capabilities)
             .forBrowser(browserInfo.browser);
     } else {
-        var options = new chromeDriver.Options();
+        var options = new chromeDriver.Options(),
+            mobileUserAgent = 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E304 Safari/602.1';
 
         options.setChromeBinaryPath(CHROMIUM_PATH);
         options.addArguments(
-            '--user-agent=Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E304 Safari/602.1',
             'headless',
             'disable-gpu'
         );
+
+        // Add mobile iPhone user agent if size is xs
+        if (task.sizeName === 'xs') {
+            options.addArguments(`user-agent=${mobileUserAgent}`);
+        }
 
         builder
             .forBrowser("chrome")

--- a/lib/selenium/screenshot.js
+++ b/lib/selenium/screenshot.js
@@ -106,8 +106,10 @@ function tryAndLoadUrl(url, driver, deferred) {
  * @param {object} task
  * @param {object} cachedDrivers
  */
-function getDriver(task, cachedDrivers) {
-    var browserShortName = task.browser;
+function getDriver(task, cachedDrivers, sizeName) {
+    var isMobile = sizeName && sizeName === 'xs',
+        browserShortName = isMobile ? `${task.browser}-mobile` : task.browser,
+        mobileUserAgent = 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E304 Safari/602.1';
 
     // we cache drivers we've previously built on this run to make things speedier
     if (cachedDrivers[browserShortName]) {
@@ -121,7 +123,7 @@ function getDriver(task, cachedDrivers) {
             "browserstack.key": process.env.DDG_BROWSERSTACK_KEY
         };
 
-    if (browserInfo.browser !== "headless-chromium") {
+    if (browserInfo.browser !== "headless-chromium" && browserInfo.browser !== "headless-chromium-mobile") {
         // copy over any browser-related settings to the capabilities
         // we pass to the third party service
         Object.keys(browserInfo).forEach(function (prop) {
@@ -137,8 +139,7 @@ function getDriver(task, cachedDrivers) {
             .withCapabilities(capabilities)
             .forBrowser(browserInfo.browser);
     } else {
-        var options = new chromeDriver.Options(),
-            mobileUserAgent = 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E304 Safari/602.1';
+        var options = new chromeDriver.Options();
 
         options.setChromeBinaryPath(CHROMIUM_PATH);
         options.addArguments(
@@ -146,8 +147,7 @@ function getDriver(task, cachedDrivers) {
             'disable-gpu'
         );
 
-        // Add mobile iPhone user agent if size is xs
-        if (task.sizeName === 'xs') {
+        if (isMobile) {
             options.addArguments(`user-agent=${mobileUserAgent}`);
         }
 
@@ -174,17 +174,17 @@ function getScreenshotPromise(task, cachedDrivers) {
     return function () {
         var deferred = webdriver.promise.defer(),
             url = "http://" + task.host + "/" + task.path,
-            driver = getDriver(task, cachedDrivers);
+            driver = getDriver(task, cachedDrivers, task.sizeName);
 
         console.log("taking screenshot for", url,
             "on", task.browser,
             (task.size ? "at " + task.size.width + "x" + task.size.height + " (" + task.sizeName + ")" : ""));
-
+        
         // set screen size for task
         if (task.size) {
             driver.manage().window().setSize(task.size.width, task.size.height);
         }
-
+        
         tryAndLoadUrl(url, driver).then(function () {
             // run any actions that we've defined
             if (task.actions) {

--- a/lib/selenium/screenshot.js
+++ b/lib/selenium/screenshot.js
@@ -225,12 +225,15 @@ exports.runTasks = function (tasks) {
         flow.on("uncaughtException", reject);
 
         tasks.forEach(function (task) {
+            var isMobile = task.sizeName && task.sizeName === "xs",
+                browserShortName = isMobile ? `${task.browser}-mobile` : task.browser;
+
             flow.execute(getScreenshotPromise(task, cachedDrivers)).then(function (screenshotBase64) {
                 task.base64Data = screenshotBase64;
                 completedTasks.push(task);
 
                 if (task.lastForBrowser) {
-                    cachedDrivers[task.browser].quit();
+                    cachedDrivers[browserShortName].quit();
                 }
             }, function fail(err) {
                 console.warn("error taking screenshot: " + err.message);

--- a/lib/selenium/screenshot.js
+++ b/lib/selenium/screenshot.js
@@ -147,6 +147,7 @@ function getDriver(task, cachedDrivers, sizeName) {
             'disable-gpu'
         );
 
+        // If it's a mobile device, add the mobile user agent
         if (isMobile) {
             options.addArguments(`user-agent=${mobileUserAgent}`);
         }

--- a/lib/selenium/screenshot.js
+++ b/lib/selenium/screenshot.js
@@ -141,6 +141,7 @@ function getDriver(task, cachedDrivers) {
 
         options.setChromeBinaryPath(CHROMIUM_PATH);
         options.addArguments(
+            '--user-agent=Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E304 Safari/602.1',
             'headless',
             'disable-gpu'
         );


### PR DESCRIPTION
**Description**
Adds a mobile user agent when the `xs` size is among the sizes specified. Note that I couldn't figure out a way to change this dynamically in selenium, so we're simply spinning up a separate browser for the mobile screenshots. There shouldn't be too much overhead, since these browsers will still be re-used during runs.

**Instructions for testing**
- Clone the repo
- `npm install`
- Take some screenshots and include the `--sizes xs` flag using the local binary: `./lib/run.js search 'map of dallas, tx' prod --sizes xs`
- These screenshots should have no horizontal scrollbar, and appear to be the mobile production experience